### PR TITLE
Update missing chaining command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,6 @@ RUN apt-get update -q && \
       groff-base && \
     pip install awscli && \
 
-    apt-get clean apt-get purge && \
+    apt-get clean && \
+    apt-get purge && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I think that the purge command could never be executed?
